### PR TITLE
build(ci): use `aarch64-apple-darwin` as the default target for  MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         platform: [
           { target: "x86_64-pc-windows-msvc", os: "windows-latest" },
           { target: "x86_64-unknown-linux-gnu", os: "ubuntu-latest" },
-          { target: "x86_64-apple-darwin", os: "macos-latest" }
+          { target: "aarch64-apple-darwin", os: "macos-latest" }
         ]
     name: Build
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
use `aarch64-apple-darwin` as the default target for  MacOS

Releated issue: actions/runner-images#9254

GitHub Action runner is using the M1 runner for `macos-latest`.
